### PR TITLE
ajust disclaimer jr/pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,3 @@ A tela deve ter como título a palavara `Gerar Arvore AVL` e o corpo dividido en
 O objetivo desta tela é desenhar uma [Árvore AVL](http://dcm.ffclrp.usp.br/~augusto/teaching/aedi/AED-I-Arvores-AVL.pdf) na tela contendo exatos numeros de nós imputados no campo intero em questão.
 
 ![home](https://github.com/trademasterbr/test-react/raw/main/wireframe/home.png)
-
-__PS:__ Caso sejas em processo para vaga de __Júnior__ ou __Júnior/Pleno__, não é necessário a implementação da [Árvore AVL](http://dcm.ffclrp.usp.br/~augusto/teaching/aedi/AED-I-Arvores-AVL.pdf), esta pode ser substituida por uma árvore em que todo nó deve ter no máximo 2 filhos.  


### PR DESCRIPTION
Seria muito remover a nota sobre junior ou pleno, a pessoa lendo nem vai tentar e podemos não detectar se a pessoa está como junior mas de fato é pleno ou mesmo senior.